### PR TITLE
Removed key attr. from all smartdashboard types

### DIFF
--- a/src/main/java/org/team2168/utils/smartdashboarddatatypes/SmartDashboardBoolean.java
+++ b/src/main/java/org/team2168/utils/smartdashboarddatatypes/SmartDashboardBoolean.java
@@ -3,8 +3,6 @@ package org.team2168.utils.smartdashboarddatatypes;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 public class SmartDashboardBoolean extends SmartDashboardObject<Boolean> {
-    private String key;
-
     public SmartDashboardBoolean(String key, Boolean value) {
         super(key, value);
     }

--- a/src/main/java/org/team2168/utils/smartdashboarddatatypes/SmartDashboardDouble.java
+++ b/src/main/java/org/team2168/utils/smartdashboarddatatypes/SmartDashboardDouble.java
@@ -8,8 +8,6 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
  * a normal double to avoid having to recompile to change a variable.
  */
 public class SmartDashboardDouble extends SmartDashboardObject<Double> {
-    private String key;
-
     public SmartDashboardDouble(String key, Double value) {
         super(key, value);
     }

--- a/src/main/java/org/team2168/utils/smartdashboarddatatypes/SmartDashboardString.java
+++ b/src/main/java/org/team2168/utils/smartdashboarddatatypes/SmartDashboardString.java
@@ -6,8 +6,6 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
  * SmartDashboardString is a helper class for getting values from Smart Dashboard
  */
 public class SmartDashboardString extends SmartDashboardObject<String> {
-    private String key;
-
     public SmartDashboardString(String key, String value) {
         super(key, value);
     }


### PR DESCRIPTION
I had forgotten how inheritance works, and this had been conflicting
with the super.key value, and was therefore resulting in a NPE, because
each constructor referenced back to the parent constructor, and therefore
the parent instance, leaving the child instance uninitialized.

By removing the key member variable from all child classes, referencing
key calls back to the abstract parent class (because this variable is
protected instead of private), and everything works as expected.